### PR TITLE
termux support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "wl-clipboard-rs",
- "x11-clipboard",
+ "x11-clipboard 0.7.1",
 ]
 
 [[package]]
@@ -485,6 +485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
 dependencies = [
  "error-code 3.2.0",
+]
+
+[[package]]
+name = "clipboard_macos"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145a7f9e9b89453bc0a5e32d166456405d389cea5b578f57f1274b1397588a95"
+dependencies = [
+ "objc",
+ "objc-foundation",
+ "objc_id",
 ]
 
 [[package]]
@@ -1013,6 +1024,7 @@ dependencies = [
  "sha256",
  "sha3",
  "signed-distance-field",
+ "terminal-clipboard",
  "texture_packer",
  "vec1",
  "walkdir",
@@ -1027,6 +1039,16 @@ name = "gethostname"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1648,6 +1670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,7 +1809,19 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -2875,6 +2918,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-clipboard"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0fd8cb5cf744b501e657eb27df7909ff917eacbfee34bc4bb13d4e6411a131"
+dependencies = [
+ "clipboard-win 4.5.0",
+ "clipboard_macos",
+ "once_cell",
+ "termux-clipboard",
+ "x11-clipboard 0.8.1",
+]
+
+[[package]]
+name = "termux-clipboard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f6aff13ca3293315b94f6dbd9c69e1c958fe421c294681e2ffda80c9858e36f"
+
+[[package]]
 name = "texture_packer"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,7 +3733,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980b9aa9226c3b7de8e2adb11bf20124327c054e0e5812d2aac0b5b5a87e7464"
 dependencies = [
- "x11rb",
+ "x11rb 0.10.1",
+]
+
+[[package]]
+name = "x11-clipboard"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41aca1115b1f195f21c541c5efb423470848d48143127d0f07f8b90c27440df"
+dependencies = [
+ "x11rb 0.12.0",
 ]
 
 [[package]]
@@ -3680,11 +3751,24 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
 dependencies = [
- "gethostname",
+ "gethostname 0.2.3",
  "nix 0.24.3",
  "winapi 0.3.9",
  "winapi-wsapoll",
- "x11rb-protocol",
+ "x11rb-protocol 0.10.0",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
+dependencies = [
+ "gethostname 0.3.0",
+ "nix 0.26.4",
+ "winapi 0.3.9",
+ "winapi-wsapoll",
+ "x11rb-protocol 0.12.0",
 ]
 
 [[package]]
@@ -3694,6 +3778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
 dependencies = [
  "nix 0.24.3",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
+dependencies = [
+ "nix 0.26.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,10 @@ crossterm_input = "0.5.0"
 open = "5.1.4"
 rand = "0.8.5"
 
-[target.'cfg(android)'.dependencies]
+[target.'cfg(target_os = "android")'.dependencies]
 terminal-clipboard = "0.4.1"
 
-[target.'cfg(not(android))'.dependencies]
+[target.'cfg(not(target_os = "android"))'.dependencies]
 cli-clipboard = "0.4.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,13 @@ which = "6.0.1"
 vec1 = { version = "1.12.1", features = ["serde"] }
 crossterm_input = "0.5.0"
 open = "5.1.4"
-cli-clipboard = "0.4.0"
 rand = "0.8.5"
+
+[target.'cfg(not(android))'.dependencies]
+cli-clipboard = "0.4.0"
+
+[target.'cfg(android)'.dependencies]
+terminal-clipboard = "0.4.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,11 @@ crossterm_input = "0.5.0"
 open = "5.1.4"
 rand = "0.8.5"
 
-[target.'cfg(not(android))'.dependencies]
-cli-clipboard = "0.4.0"
-
 [target.'cfg(android)'.dependencies]
 terminal-clipboard = "0.4.1"
+
+[target.'not(cfg(android))'.dependencies]
+cli-clipboard = "0.4.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ rand = "0.8.5"
 [target.'cfg(android)'.dependencies]
 terminal-clipboard = "0.4.1"
 
-[target.'not(cfg(android))'.dependencies]
+[target.'cfg(not(android))'.dependencies]
 cli-clipboard = "0.4.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/index_auth.rs
+++ b/src/index_auth.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "android"))]
 use cli_clipboard::ClipboardProvider;
 use reqwest::header::USER_AGENT;
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,22 @@ struct LoginAttempt {
 #[derive(Serialize)]
 struct LoginPoll {
 	uuid: String,
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn copy_token(token: &str) {
+	if let Ok(mut ctx) = cli_clipboard::ClipboardContext::new() {
+		if ctx.set_contents(token.to_string()).is_ok() {
+			done!("Token has been copied to your clipboard");
+		}
+	}
+}
+
+#[cfg(target_os = "android")]
+pub fn copy_token(token: &str) {
+	if terminal_clipboard::set_string(token).is_ok() {
+		done!("Token has been copied to your clipboard");
+	}
 }
 
 pub fn login(config: &mut Config) {
@@ -50,11 +67,7 @@ pub fn login(config: &mut Config) {
 	info!("You will need to complete the login process in your web browser");
 	info!("Go to: {} and enter the login code", &login_data.uri);
 	info!("Your login code is: {}", &login_data.code);
-	if let Ok(mut ctx) = cli_clipboard::ClipboardContext::new() {
-		if ctx.set_contents(login_data.code.to_string()).is_ok() {
-			info!("The code has been copied to your clipboard");
-		}
-	}
+	copy_token(&login_data.code);
 	open::that(&login_data.uri).nice_unwrap("Unable to open browser");
 
 	loop {

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -174,6 +174,8 @@ impl Profile {
 	pub fn geode_dir(&self) -> PathBuf {
 		if self.platform == "win" {
 			self.gd_path.parent().unwrap().join("geode")
+		} else if self.platform == "android32" || self.platform == "android64" {
+			self.gd_path.join("game/geode")
 		} else {
 			self.gd_path.join("Contents/geode")
 		}


### PR DESCRIPTION
- Uses a separate clipboard library on android (doesn't replace on other platforms)
- Fixes geode dir path getter (it tried to use macOS paths)